### PR TITLE
Add error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ module.exports = {
     new JscramblerWebpack({
       enable: true, // optional, defaults to true
       chunks: ['protected'] // optional, defaults to all chunks
+      params: [], 
+      applicationTypes: {}
+      // and other jscrambler configurations
     })
   ]
 };
 ```
 
-The Jscrambler client will use .jscramblerrc as usual, though it is possible to override specific values using the plugin's configuration
+The Jscrambler client will use .jscramblerrc as usual, though it is possible to override specific values using the plugin's configuration.
 
 Additionally, you may specify which chunks to protect using the `chunks` property, which accepts an array with the names of the chunks you wish to protect.

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ class JscramblerPlugin {
         }
 
         chunk.files.forEach((filename) => {
-          if (/\.(jsx?|map|html|htm)$/.test(filename)) {
+          if (/\.(js|map|html|htm)$/.test(filename)) {
             const content = compilation.assets[filename].source();
 
             sources.push({content, filename});
@@ -43,7 +43,7 @@ class JscramblerPlugin {
           ), res => this.processResult(res, compilation, callback))
         )
         .catch((err) => {
-          callback(`Jscrambler Error: ${err.message}`);
+          callback(`Jscrambler ${err}`);
         });
       } else {
         callback();

--- a/src/index.js
+++ b/src/index.js
@@ -33,13 +33,18 @@ class JscramblerPlugin {
       });
 
       if (sources.length > 0) {
-        client.protectAndDownload(Object.assign(
-          this.options,
-          {
-            sources,
-            stream: false
-          }
-        ), res => this.processResult(res, compilation, callback));
+        Promise.resolve(
+          client.protectAndDownload(Object.assign(
+            this.options,
+            {
+              sources,
+              stream: false
+            }
+          ), res => this.processResult(res, compilation, callback))
+        )
+        .catch((err) => {
+          callback(`Jscrambler Error: ${err.message}`);
+        });
       } else {
         callback();
       }


### PR DESCRIPTION
Ideally `compilations.errors.push(err)` would be used but this doesn't stop the compilation process. Calling the callback with the error is sufficient in making sure the webpack build isn't successful.